### PR TITLE
Show local pricing for recurring levels that have a free trial period

### DIFF
--- a/pmpro-local-pricing.php
+++ b/pmpro-local-pricing.php
@@ -174,7 +174,7 @@ function pmpro_local_get_local_cost_text( $level_id, $discount_code = false ) {
 	$local_initial = $level->initial_payment * $exchange_rate;
 	$local_billing = $level->billing_amount * $exchange_rate;
 
-	if ( $local_initial < 1 ) {
+	if ( $local_initial < 1 && $local_billing < 1 ) {
 		return;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-local-pricing/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-local-pricing/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Local Pricing would not display for recurring membership levels with zero initial payment. 

This change resolves the issue by hiding local pricing only if both initial and recurring billing amount are <1


### How to test the changes in this Pull Request:

1. Create a membership level with Initial Payment of $0 and set a Billing Amount.
2. Visit checkout page for the level. Observe that local pricing is not shown.
3. Apply PR.
4. Visit checkout page for the level. Observe that local pricing is shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Show local pricing for recurring levels that have a free trial period