### PR TITLE
Fixed display issues for low amount levels.

### DIFF
--- a/pmpro-local-pricing.php
+++ b/pmpro-local-pricing.php
@@ -155,6 +155,11 @@ function pmpro_local_get_local_cost_text( $level_id, $discount_code = false ) {
 	$level = pmpro_getLevelAtCheckout( intval( $level_id ), $discount_code );
 	$currency = pmpro_local_get_currency_based_on_location();
 
+	// If the level is free, let's bail.
+	if ( pmpro_isLevelFree( $level ) ) {
+		return;
+	}
+
 	// If there's no difference in the currency between the user, or unable to get the currency just bail.
 	if ( ! $currency ) {
 		return;
@@ -173,10 +178,6 @@ function pmpro_local_get_local_cost_text( $level_id, $discount_code = false ) {
 	// Let's see if a discount code is used.
 	$local_initial = $level->initial_payment * $exchange_rate;
 	$local_billing = $level->billing_amount * $exchange_rate;
-
-	if ( $local_initial < 1 ) {
-		return;
-	}
 
 	$allowed_html = array( 'strong' => array() );
 	if ( $level->initial_payment == $level->billing_amount || $level->billing_amount == 0 ) {


### PR DESCRIPTION
* ENHANCEMENT: Added better support for low amount levels (such as $0.99) and doesn't show for free levels.

This should also improve compatibility for recurring levels, it needs some more testing for subscription delays and $0 initial amount levels with a recurring payment amount. Similarly related to this PR -> https://github.com/strangerstudios/pmpro-local-pricing/pull/9

### All Submissions:
* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-local-pricing/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-local-pricing/pulls) for the same update/change?