### PR TITLE
Add support for PMPro 3.5+

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -1,27 +1,51 @@
 <?php
 /**
  * Add a settings field to the Payment Settings page for API Keys and other settings.
+ * This uses a @deprecated hook that is no longer supported in Paid Memberships Pro <V3 class="5">
+ * 
  */
-function pmpro_local_payment_option_fields( $options, $gateway ) {
-    global $pmpro_countries;
-    $app_id = get_option( 'pmpro_local_pricing_app_id' );
+
+/**
+ * Loads the relevant settings for the Local Pricing Add On based on PMPro core version.
+ * This helps support Paid Memberships Pro V3.5+ and older versions.
+ * Note: This function can be removed and deprecated in a future version of the plugin.
+ *
+ * @since TBD
+ */
+function pmpro_local_backwards_compatibility_settings() {
+	if ( version_compare( PMPRO_VERSION, '3.5', '<' ) ) {
+		// The previous version of loading the setting has been adjusted. Keeping this function for any custom code (such as function exist checks etc.)
+		function pmpro_local_payment_option_fields( $options, $gateway ) {
+			echo pmpro_local_show_option_fields();
+		}
+		add_action( 'pmpro_payment_option_fields', 'pmpro_local_payment_option_fields', 10, 2 );
+	}
+}
+add_action( 'init', 'pmpro_local_backwards_compatibility_settings' );
+
+/**
+ * Show the App ID in the Payment Settings, this helps resolve backwards compatibility issues for Paid Memberships Pro V3.5+
+ * 
+ * @since TBD
+ * 
+ */
+function pmpro_local_show_option_fields() {
+	$app_id = get_option( 'pmpro_local_pricing_app_id' );
 ?>
-    <tr class="pmpro_settings_divider">
-        <td colspan="2">
-            <hr>
-            <h3><?php esc_html_e( 'Local Pricing Settings', 'pmpro-local-pricing' ); ?></h3>
-        </td>
-    </tr>
-    <tr>
-        <th><label for="pmpro_local_app_id"><?php esc_html_e( 'App ID', 'pmpro-local-pricing' ); ?></label></th>
-        <td>
-            <input type="text" name="pmpro_local_app_id" id="pmpro_local_app_id" value="<?php echo esc_attr( $app_id ); ?>"/>
-            <p class="description"><?php echo esc_html__( 'Manage your APP ID here: ', 'pmpro-local-pricing' ) . '<a href="https://openexchangerates.org/" target="_blank">https://openexchangerates.org/</a>. ' . esc_html__( 'Please note that a paid account is required if your site currency is not USD.', 'pmpro-local-pricing' ); ?></p>
-        </td>
-    </tr>
+<table class="form-table">
+	<tr>
+		<th>
+			<label for="pmpro_local_app_id"><?php esc_html_e( 'Local Pricing APP ID', 'pmpro-local-pricing' ); ?></label>
+		</th>
+		<td>
+			<input type="text" name="pmpro_local_app_id" id="pmpro_local_app_id" value="<?php echo esc_attr( $app_id ); ?>"/>
+			<p class="description"><?php echo esc_html__( 'Manage your APP ID here: ', 'pmpro-local-pricing' ) . '<a href="https://openexchangerates.org/" target="_blank">https://openexchangerates.org/</a>. ' . esc_html__( 'Please note that a paid account is required if your site currency is not USD.', 'pmpro-local-pricing' ); ?></p>
+		</td>
+	</tr>
+</table>
 <?php
 }
-add_action( 'pmpro_payment_option_fields', 'pmpro_local_payment_option_fields', 10, 2 );
+add_action( 'pmpro_after_payment_settings', 'pmpro_local_show_option_fields' );
 
 /**
  * Save settings for the App ID.


### PR DESCRIPTION
* ENHANCEMENT: Added support for Paid Memberships Pro 3.5+ and keep backwards compatibility for older versions to not fatal error.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-local-pricing/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-local-pricing/pulls) for the same update/change?