### PR TITLE
[ENHANCEMENT] Add support for custom exchange rate API via filter

### DIFF
--- a/pmpro-local-pricing.php
+++ b/pmpro-local-pricing.php
@@ -113,16 +113,36 @@ function pmpro_local_exchange_rate( $site_currency, $currency ) {
 		return $exchange_rate->$currency;
 	}
 
-	$raw_url = 'https://openexchangerates.org/api/latest.json';
-
-	// Make a remote request to openexchangerate.org
-	$params = array(
-		'app_id' => esc_attr( get_option( 'pmpro_local_pricing_app_id' ) ),
-		'base'   => $site_currency,
-	);
-
-	// add query args
-	$url = add_query_arg( $params, $raw_url );
+	/**
+	 * Filter to use a custom exchange rate API.
+	 * 
+	 * The API must return JSON in this format:
+	 * {
+	 *   "rates": {
+	 *     "USD": 1,
+	 *     "EUR": 0.85,
+	 *     "GBP": 0.73
+	 *   }
+	 * }
+	 * 
+	 * Note: APIs that use concatenated currency codes (e.g., "USDEUR": 0.85) are not supported.
+	 * 
+	 * @param string $custom_api_url The custom API URL (should include API key if needed).
+	 */
+	$custom_api_url = apply_filters( 'pmpro_local_pricing_custom_api_url', '' );
+	
+	if ( ! empty( $custom_api_url ) ) {
+		$url = $custom_api_url;
+	} else {
+		// Use default Open Exchange Rates with app_id and base
+		$app_id = apply_filters( 'pmpro_local_pricing_app_id', get_option( 'pmpro_local_pricing_app_id' ) );
+		$raw_url = 'https://openexchangerates.org/api/latest.json';
+		$params = array(
+			'app_id' => esc_attr( $app_id ),
+			'base'   => $site_currency,
+		);
+		$url = add_query_arg( $params, $raw_url );
+	}
 
 	// Let's get the exchange data now.
 	$response = wp_remote_get( $url );
@@ -139,6 +159,9 @@ function pmpro_local_exchange_rate( $site_currency, $currency ) {
 	$response_body = json_decode( wp_remote_retrieve_body( $response ) );
 
 	// Get the exchange rate for the currency.
+	if ( empty( $response_body->rates ) ) {
+		return false;
+	}
 	$exchange_rate = $response_body->rates;
 
 	// Set the transient for this currency.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-local-pricing/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-local-pricing/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds support for custom exchange rate APIs as an alternative to Open Exchange Rates.

- Added `pmpro_local_pricing_custom_api_url` filter for custom API endpoints
- Added `pmpro_local_pricing_app_id` filter to override app_id programmatically
- Improved error handling for missing `rates` in API response
- Fully backward compatible

Custom APIs must return JSON with `rates` object: `{"rates": {"USD": 1, "EUR": 0.85}}`

### How to test the changes in this Pull Request:

1. Test default behavior with Open Exchange Rates API
2. Test custom API filter:
   ```php
   add_filter( 'pmpro_local_pricing_custom_api_url', function() {
      return 'https://api.frankfurter.dev/v1/latest';
   } );
   ```
3. (Optional, some APIs don't need keys) Set APP ID with custom API keys or override them with:
   ```php
   add_filter( 'pmpro_local_pricing_app_id', function() {
      return 'API_KEYS';
   } );
   ```
4. Verify exchange rates display correctly at checkout

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Added `pmpro_local_pricing_custom_api_url` and `pmpro_local_pricing_app_id` filters to support alternative exchange rate API providers.

> Note: This feature was developed with the assistance of AI.