### PR TITLE
Add filter to short-circuit exchange rate lookup

### DIFF
--- a/pmpro-local-pricing.php
+++ b/pmpro-local-pricing.php
@@ -105,6 +105,25 @@ function pmpro_local_get_currency_based_on_location() {
  */
 function pmpro_local_exchange_rate( $site_currency, $currency ) {
 
+	/**
+	 * Filter to short-circuit the exchange rate lookup.
+	 *
+	 * Return a numeric value to skip the default Open Exchange Rates API call
+	 * and the plugin's transient cache. This lets developers use any rate source
+	 * (alternative API, local data, hardcoded values, etc.) without having to
+	 * match the Open Exchange Rates JSON shape.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $exchange_rate Default null. Return a numeric rate to short-circuit, or false to short-circuit with "no rate available".
+	 * @param string $site_currency The site's base currency.
+	 * @param string $currency      The user's currency.
+	 */
+	$exchange_rate = apply_filters( 'pmpro_local_pricing_custom_exchange_rate', null, $site_currency, $currency );
+	if ( null !== $exchange_rate ) {
+		return $exchange_rate;
+	}
+
 	// Get transient for this currency ( 1 hour )
 	$exchange_rate = get_transient( 'pmpro_local_exchange_rate_' . $site_currency );
 
@@ -137,6 +156,11 @@ function pmpro_local_exchange_rate( $site_currency, $currency ) {
 
 	// Get the body of the response.
 	$response_body = json_decode( wp_remote_retrieve_body( $response ) );
+
+	// If the response body is empty or doesn't contain rates, bail.
+	if ( empty( $response_body->rates ) ) {
+		return false;
+	}
 
 	// Get the exchange rate for the currency.
 	$exchange_rate = $response_body->rates;


### PR DESCRIPTION
## Summary
- Adds the `pmpro_local_pricing_custom_exchange_rate` filter, letting developers short-circuit the exchange rate lookup with any value source (alternative API, local data, env var, hardcoded table, etc.) without having to match the Open Exchange Rates JSON shape.
- Fires before the transient cache lookup since a filter user manages their own caching — the plugin's transient would never be populated when the default API path is bypassed.
- Default value is `null` so developers can still return `false` from the filter to signal "no rate available, don't fall back to the default API."
- Adds a defensive guard for an empty or missing `rates` property on the API response, preventing a stale transient from being set when the API returns an error payload.

This is an alternative design to #15. Rather than swapping out the API URL (which forces the response JSON to match the Open Exchange Rates shape), this filter lets developers replace the entire lookup with any rate source — works with APIs that use concatenated codes (`USDEUR`), local data files, env-var-driven hardcoded rates, anything.

## Test plan
- [ ] With no filter hooked: confirm rates still come from Open Exchange Rates and pricing displays correctly at checkout.
- [ ] Hook the filter returning a numeric rate (e.g. `0.85`): confirm `pmpro_local_get_local_cost_text` uses that rate and the default API is not called.
- [ ] Hook the filter returning `false`: confirm `pmpro_local_exchange_rate` returns false and no local price is rendered.
- [ ] Hook the filter returning `null`: confirm the default API path runs as before.
- [ ] Stub a 200 response with an empty body / missing `rates`: confirm function returns false and no transient is set.
